### PR TITLE
[wip] work on umbrella publication

### DIFF
--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -42,6 +42,7 @@ tasks {
 
 npmPublishing {
   organization = "$group"
+  experimentalUmbrellaMode = true
   publications {
     named("js") {
       moduleName = "sandbox"

--- a/sandbox/build.gradle.kts
+++ b/sandbox/build.gradle.kts
@@ -31,7 +31,7 @@ kotlin {
 }
 
 tasks {
-  named("compileProductionLibraryKotlinJs", KotlinJsCompile::class.java) {
+  withType<KotlinJsCompile>() {
     kotlinOptions {
 //      sourceMap = true
 //      sourceMapEmbedSources = "always"

--- a/src/main/kotlin/NpmPublishPlugin.kt
+++ b/src/main/kotlin/NpmPublishPlugin.kt
@@ -147,15 +147,21 @@ class NpmPublishPlugin : Plugin<Project> {
           }
         packTask.dependsOn(npmPackTask)
         packTask.enabled = true
-        repositories.map { repo ->
-          val upperRepoName = GUtil.toCamelCase(repo.name)
-          val publishTaskName = "publish${upperName}NpmPublicationTo$upperRepoName"
-          tasks.findByName(publishTaskName)
-            ?: tasks.create(publishTaskName, NpmPublishTask::class.java, pub, repo).also { task ->
-              task.onlyIf { assemblePackageTask.didWork }
-              task.dependsOn(assemblePackageTask)
-              publishTask.dependsOn(task)
-            }
+
+        if (rootProject.npmPublishing.experimentalUmbrellaMode && this != rootProject) {
+          // no publish tasks for non-root projects in umbrella mode!
+          emptyList()
+        } else {
+          repositories.map { repo ->
+            val upperRepoName = GUtil.toCamelCase(repo.name)
+            val publishTaskName = "publish${upperName}NpmPublicationTo$upperRepoName"
+            tasks.findByName(publishTaskName)
+              ?: tasks.create(publishTaskName, NpmPublishTask::class.java, pub, repo).also { task ->
+                task.onlyIf { assemblePackageTask.didWork }
+                task.dependsOn(assemblePackageTask)
+                publishTask.dependsOn(task)
+              }
+          }
         }
       }
       if (pubTasks.isNotEmpty()) {

--- a/src/main/kotlin/dsl/NpmPublishExtension.kt
+++ b/src/main/kotlin/dsl/NpmPublishExtension.kt
@@ -50,6 +50,18 @@ open class NpmPublishExtension(private val project: Project) : NpmPublishExtensi
   var shrinkwrapBundledDependencies: Boolean by project.propertyDelegate(default = true) { it.notFalse() }
 
   /**
+   * Specifies if experimental umbrella publishing should be used.
+   *
+   * Umbrella publishing publishes all dependendencies of this project as independent artifacts, rather than as one
+   * combined artifact.
+   *
+   * Should be combined with IR and `-xir-per-module` compiler flag.
+   *
+   * Defaults to `npm.publish.experimentalUmbrellaMode` project property if set, or `false` otherwise.
+   */
+  var experimentalUmbrellaMode: Boolean by project.propertyDelegate(default = false) { it.notFalse() }
+
+  /**
    * Specifies if a dry-run should be added to the npm command arguments.
    * Dry run does all the normal run des except actual file uploading.
    * Defaults to `npm.publish.dry` project property if set or `false` otherwise.


### PR DESCRIPTION
Tasks
- [x] add `umbrella` flag to plugin and root project
- [x] skip adding the publication task on subprojects if `rootProject.umbrella = true` and `project != rootProject`
- [ ] for `rootProject`, implement logic to collect all valid subprojects
  - [ ] `npm-publish` + kotlin (js/mpp) plugins applied
  - [ ] Log a warning if such subprojects have more than 1 js target
- [ ] build `rootProject`
  - [ ] maybe ensure  `-Xir-per-module` is set?
- [ ] for each valid subproject:
  - [ ] combine subproject plugin + rootproject customization 
  - [ ] pack subproject
  - [ ] assemble new pack contents using 
    - [ ] module `.js` and `.js.map` files from rootproject build
    - [ ] `.d.ts` and `package.json` from subproject builds
  - [ ] should have transitive dependencies reflected in `package.json`
- [ ] update `*.js` files to use module names rather than local imports
  - [ ] for project modules
  - [ ] for external kotlin dependencies
  - [ ] for npm dependencies
- [ ] for external kotlin dependencies
  - [ ] should have an artifact generated
  - [ ] should have a way to configure naming
  - [ ] should have transitive dependencies pulled in
  - [ ] imports should be updated
- [ ] for npm dependencies
  - [ ] shouldn't have an artifact generated
  - [ ] should be reflected in `package.json` for dependent packages
  - [ ] imports should be updated
- [ ] loosen constraints so we can use publish any project (and its dependencies) in umbrella mode, rather than needing to hardcode rootProject


Desired DSL
```kotlin
npmPublishing {
  umbrella = true
  publications {
    named("subA") { // Only created if subA project has plugin applied and has exactly 1 js target declared. Errors on more than one target.
      // subA publication customisation
    }
    named("subB") { // Only created if subB project has plugin applied and has exactly 1 js target declared. Errors on more than one target.
      // subB publication customisation
    }
    named("root") { // Only created if root project has exactly 1 js target declared. Does not error otherwise
      // subA publication customisation
    }
  }
}
```
